### PR TITLE
SPARQL Visualization: updated block merging

### DIFF
--- a/app/imports/custom/vq/client/js/generateVisualQuery.js
+++ b/app/imports/custom/vq/client/js/generateVisualQuery.js
@@ -651,7 +651,6 @@ class Graph {
         const canMerge =
           !hasAbsorbableChildren &&
           innerGraph.size > 1 &&
-          !graphsService &&
           inner.conditions.length === 0 &&
           !hasNonTrivialAttributes;
 
@@ -670,9 +669,22 @@ class Graph {
             isInverse = true;
           }
 
-          if (connectingEdge) {
-            connectingEdge.nestingType = nestingType;
-            connectingEdge.linkType = linkType;
+          const hasNestingConflict =
+            connectingEdge &&
+            connectingEdge.nestingType !== NestingType.Plain &&
+            nestingType !== NestingType.Plain;
+          const hasLinkConflict =
+            connectingEdge &&
+            connectingEdge.linkType !== LinkType.Required &&
+            linkType !== LinkType.Required;
+
+          if (connectingEdge && !hasNestingConflict && !hasLinkConflict) {
+            if (nestingType !== NestingType.Plain) {
+              connectingEdge.nestingType = nestingType;
+            }
+            if (linkType !== LinkType.Required) {
+              connectingEdge.linkType = linkType;
+            }
             if (!isInverse) {
               connectingEdge.from = outer;
               outer.outgoing.push(connectingEdge);


### PR DESCRIPTION
- Allow merge between `GRAPH`/`SERVICE` blocks
- Fix incorrect merging in multi-level block structure when block types differ. Preserve non-default inner block `nestingType` and `linkType`.  Fixes visualization of queries containing `OPTIONAL` inside subqueries when `OPTIONAL` is merged with subquery and subquery is merged with the main query. Previously the outer merge overwrote the inner `Optional` `linkType` with `Required`.