### PR TITLE
Minor rdf-toolbag related changes

### DIFF
--- a/app/imports/custom/vq/client/templates/generate_complex_table_query_form.js
+++ b/app/imports/custom/vq/client/templates/generate_complex_table_query_form.js
@@ -59,11 +59,6 @@ function switchToEditorTab() {
  * @return {Promise<{label: string, value: string}[]>}
  */
 async function getPropertySuggestions(selectedType, propertyType, limit) {
-    console.log({ selectedType, propertyType });
-
-    // NOTE: There's probably a bunch of properties to suggest when no type is known but for now
-    // we will return empty array.
-    if (!selectedType) return [];
     const props = await getProperties(selectedType, propertyType, limit);
     if (!props) return [];
     return props.map(({ iri, prefixedName }) => ({

--- a/app/imports/custom/vq/client/templates/generate_complex_table_query_form.js
+++ b/app/imports/custom/vq/client/templates/generate_complex_table_query_form.js
@@ -127,7 +127,7 @@ function useSyncWithDiagram(setSelection) {
     }
 
     const dataLimit = 5;
-    const objLimit = 3;
+    const objLimit = 2;
 
     /**
      * @param {{[key: string]: string}} prefixes

--- a/app/imports/custom/vq/client/templates/grouped_results_paginated.js
+++ b/app/imports/custom/vq/client/templates/grouped_results_paginated.js
@@ -243,7 +243,7 @@ export function GroupedResultsPaginated() {
         return executeUnlimited(query);
       },
       baseQuery: savedQuery,
-      counterLimit: 10_000_000,
+      counterLimit: 100_000,
       rawRowLimit: 100_000,
       idVars,
       pagination,

--- a/app/imports/custom/vq/client/templates/sparql_form.html
+++ b/app/imports/custom/vq/client/templates/sparql_form.html
@@ -4,7 +4,7 @@
         <ul class="nav nav-tabs" id="vq-tab">
             <li class="active"><a data-toggle="tab" href="#sparql">SPARQL</a></li>
             <li><a data-toggle="tab" href="#executed">Results</a></li>
-            <li><a data-toggle="tab" href="#extraResultsPaginated">Grouped results Paginated</a></li>
+            <li><a data-toggle="tab" href="#extraResultsPaginated">Grouped Results</a></li>
             <!--<li class="disabled"><a data-toggle="tab" href="#">Messages</a></li>-->
         </ul>
         <div class="tab-content">

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,7 +19,7 @@
         "jquery": "^3.7.1",
         "json2csv": "^5.0.7",
         "meteor-node-stubs": "^1.2.27",
-        "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.0",
+        "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.1",
         "rdflib": "2.3.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -11486,8 +11486,8 @@
       }
     },
     "node_modules/rdf-toolbag": {
-      "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/3starblaze/rdf-toolbag.git#e758042e031b6c2aba9b86ae875b08b4676b05f7",
+      "version": "0.3.1",
+      "resolved": "git+ssh://git@github.com/3starblaze/rdf-toolbag.git#61554ed48d290db0bb365bab46a28baddbe92aa9",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,7 @@
     "jquery": "^3.7.1",
     "json2csv": "^5.0.7",
     "meteor-node-stubs": "^1.2.27",
-    "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.0",
+    "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.1",
     "rdflib": "2.3.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
- Update to rdf-toolbag v0.3.1 -- generated queries are reordered so that basic graph patterns always appear before OPTIONAL patterns
  - Rename "Grouped results Paginated"
  - Change property suggestion count to 5+2
  - Fix property suggestions without type
  - Reduce counter limit to prevent timeout