### PR TITLE
Update rdf-toolbag to v0.3.4

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,7 +20,7 @@
         "jquery": "^3.7.1",
         "json2csv": "^5.0.7",
         "meteor-node-stubs": "^1.2.27",
-        "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.3",
+        "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.4",
         "rdflib": "2.3.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -11487,8 +11487,8 @@
       }
     },
     "node_modules/rdf-toolbag": {
-      "version": "0.3.3",
-      "resolved": "git+ssh://git@github.com/3starblaze/rdf-toolbag.git#356c1592b27a2a45e99b60b9a02fd9bf6d70dd0f",
+      "version": "0.3.4",
+      "resolved": "git+ssh://git@github.com/3starblaze/rdf-toolbag.git#54fd285fbfc2bd145ba034025d87b32a41a61034",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "jquery": "^3.7.1",
     "json2csv": "^5.0.7",
     "meteor-node-stubs": "^1.2.27",
-    "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.3",
+    "rdf-toolbag": "github:3starblaze/rdf-toolbag#semver:0.3.4",
     "rdflib": "2.3.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
With rdf-toolbag v0.3.4:
- Generated queries now inherit "ORDER BY" so that results are always correctly ordered
- Adapt counter query to work on QLever-based SPARQL endpoints (to avoid the bug that can be seen in https://github.com/ad-freiburg/qlever/issues/3158 )